### PR TITLE
Update Travis configuration for PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ php:
     - 5.6
     - 7.0
 
-matrix:
-  allow_failures:
-    - php: 7.0
-
 before_script:
     - export DISPLAY=:99.0
     - Xvfb $DISPLAY -extension RANDR &> /dev/null &


### PR DESCRIPTION
Since PHP7 is released, travis tests are not allowed to fail.
